### PR TITLE
Support detection of NF blade card availability on each slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,22 @@
 # nf-power-control
-This daemon is to generate NF card slot power on/off DBus path and could be set from host to control NF card slot. 
+This daemon is to generate NF card slot power control DBus objects and 
+could be set from host to control NF card slot. 
 
-* DBus Service: ```xyz.openbmc_project.Control.NF.Power```
-* DBus Interface: ```xyz.openbmc_project.Control.NF.Power```
-* DBus SLOT_PWR Path: ```/xyz/openbmc_project/control/nf/slot_x_pwr```
+* DBus Service: ```xyz.openbmc_project.nf.power.manager```
+* DBus Interface: ```xyz.openbmc_project.NF.Blade.Power```
 
-SLOT_PWR are the GPIO pins from GPIO expanders and they have to be set as gpio-line-names in Kernel DTS file.
-* SLOT_PWR gpio-line-names: ```slot_x_pwr```
+* Attached Property (read-only): ```/xyz/openbmc_project/control/nf/bladex/attr/Attached```   
+(x.true: One NF card is attached onto slot #.x)   
+(x.false: NO NF card is attached onto slot #.x)   
+Such property is controlled by GPIO line SLOT_PRSNT
+
+* Asserted Property (read-write): ```/xyz/openbmc_project/control/nf/bladex/attr/Asserted```
+(Power.on: Power on the NF card on slot #.x)   
+(Power.off: Power off the NF card on slot #.x)   
+Such property is controlled by GPIO line SLOT_PWR
+
+SLOT_PRSNT and SLOT_PWR are the GPIO pins from GPIO expanders and 
+they have to be set as gpio-line-names in Kernel DTS file.
+* SLOT_PRSNT gpio-line-names: ```slot_x_prsnt```     
+* SLOT_PWR gpio-line-names: ```slot_x_pwr```     
+

--- a/meson.build
+++ b/meson.build
@@ -27,8 +27,8 @@ systemd = dependency('systemd')
 conf_data = configuration_data()
 conf_data.set('bindir', get_option('prefix') / get_option('bindir'))
 configure_file(
-  input: 'xyz.openbmc_project.Control.NF.Power.service.in',
-  output: 'xyz.openbmc_project.Control.NF.Power.service',
+  input: 'xyz.openbmc_project.nf.power.manager.service.in',
+  output: 'xyz.openbmc_project.nf.power.manager.service',
   configuration: conf_data,
   install: true,
   install_dir: systemd.get_pkgconfig_variable('systemdsystemunitdir'))

--- a/nf_pwr_ctrl.cpp
+++ b/nf_pwr_ctrl.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <ctype.h>
 #include <sdbusplus/asio/object_server.hpp>
+#include <sdbusplus/vtable.hpp>
 #include <variant>
 
 #define MAX_NF_CARD_NUMS 16
@@ -13,17 +14,21 @@ namespace nf_pwr_ctrl
 {
 static boost::asio::io_service io;
 static std::shared_ptr<sdbusplus::asio::connection> conn;
-static std::shared_ptr<sdbusplus::asio::dbus_interface> nfpwrIface[MAX_NF_CARD_NUMS];
+static std::shared_ptr<sdbusplus::asio::dbus_interface> nfBladeIface[MAX_NF_CARD_NUMS];
 
-static constexpr const char* nfPowerService = "xyz.openbmc_project.Control.NF.Power";
-static constexpr const char* nfPowerIface = "xyz.openbmc_project.Control.NF.Power";
+static constexpr const char* nfPowerService = "xyz.openbmc_project.nf.power.manager";
+static constexpr const char* nfPowerIface = "xyz.openbmc_project.NF.Blade.Power";
 static std::string nfPowerPath = "/xyz/openbmc_project/control/nf/";
+static std::string nfBladePath[MAX_NF_CARD_NUMS];
+
 static std::string nfpwrTemplate = "slot_x_pwr";
-static std::string nfpwrPath[MAX_NF_CARD_NUMS];
 static std::string nfpwrOut[MAX_NF_CARD_NUMS];
 
-static bool setGPIOOutput(const std::string& name, const int value,
-                          gpiod::line& gpioLine)
+static std::string nfprsntTemplate = "slot_x_prsnt";
+static std::string nfprsntIn[MAX_NF_CARD_NUMS];
+
+static bool GPIOLine(const std::string& name, const int out,
+                          gpiod::line& gpioLine, int& value)
 {
     // Find the GPIO line
     gpioLine = gpiod::find_line(name);
@@ -33,29 +38,33 @@ static bool setGPIOOutput(const std::string& name, const int value,
         return false;
     }
 
-    // Request GPIO output to specified value
+    // Request GPIO line as input/output
     try
     {
-        gpioLine.request({__FUNCTION__, gpiod::line_request::DIRECTION_OUTPUT},
+		if(out)
+			gpioLine.request({__FUNCTION__, gpiod::line_request::DIRECTION_OUTPUT},
                          value);
+		else {
+			gpioLine.request({__FUNCTION__, gpiod::line_request::DIRECTION_INPUT});
+			value = gpioLine.get_value();
+		}
     }
     catch (std::exception&)
     {
-        std::cerr << "Failed to request " << name << " output\n";
+        std::cerr << "Failed to request " << name << "\n";
         return false;
     }
 
-    std::cerr << name << " set to " << std::to_string(value) << "\n";
     return true;
 }
 
-static void PowerStateMonitor()
+static void PowerControl()
 {
     static auto match = sdbusplus::bus::match::match(
         *conn,
         "type='signal',member='PropertiesChanged', "
         "interface='org.freedesktop.DBus.Properties', "
-        "arg0namespace=xyz.openbmc_project.Control.NF.Power",
+        "arg0namespace=xyz.openbmc_project.NF.Blade.Power",
         [](sdbusplus::message::message& m) {
             std::string intfName;
             boost::container::flat_map<std::string,
@@ -83,11 +92,14 @@ static void PowerStateMonitor()
                 std::cerr << "state: " << state << "\n";
                 gpiod::line line;
                 int value;
-                if (state == "xyz.openbmc_project.Control.NF.Power.On")
-                    value = 0;
-                else
-                    value = 1;
-                setGPIOOutput(line_name, value, line);
+
+				if (state == "Power.On")
+					value = 0;
+				else
+					value = 1;
+
+				GPIOLine(line_name, 1, line, value);
+
                 // Release line
                 line.reset();
             }
@@ -107,6 +119,7 @@ int main(int argc, char* argv[])
         std::make_shared<sdbusplus::asio::connection>(nf_pwr_ctrl::io);
 
     nf_pwr_ctrl::conn->request_name(nf_pwr_ctrl::nfPowerService);
+
     sdbusplus::asio::object_server server =
         sdbusplus::asio::object_server(nf_pwr_ctrl::conn);
 
@@ -114,42 +127,87 @@ int main(int argc, char* argv[])
     int i;
 
     for (i = 0; i < MAX_NF_CARD_NUMS; i++) {
-		/** set gpio name */
+		/** construct slot_x_pwr gpio name */
         gpio_name.clear();
         gpio_name.assign(nf_pwr_ctrl::nfpwrTemplate);
         gpio_name.replace(gpio_name.find("x"), 1, std::to_string(i));
 
-		/** set gpio dbus object */
-        nf_pwr_ctrl::nfpwrPath[i] = 
-            nf_pwr_ctrl::nfPowerPath + gpio_name;
-
-		/** set phsical gpio name */
+		/** set slot_x_pwr physical gpio name */
         nf_pwr_ctrl::nfpwrOut[i].assign(gpio_name);
 
-		/** setup new dbus REST interface */
-        nf_pwr_ctrl::nfpwrIface[i] = 
-            server.add_interface(
-                 nf_pwr_ctrl::nfpwrPath[i], nf_pwr_ctrl::nfPowerIface);
+		/** construct slot_x_prsnt gpio name */
+        gpio_name.clear();
+        gpio_name.assign(nf_pwr_ctrl::nfprsntTemplate);
+        gpio_name.replace(gpio_name.find("x"), 1, std::to_string(i));
 
-		/** add new dbus event to the newly dbus object */
-        nf_pwr_ctrl::nfpwrIface[i]->register_property("Asserted",
-            std::string("xyz.openbmc_project.Control.NF.Power.Off"),
+		/** set slot_x_prsnt physical gpio name */
+        nf_pwr_ctrl::nfprsntIn[i].assign(gpio_name);
+
+		/** set nf blade dbus path */
+        nf_pwr_ctrl::nfBladePath[i] = 
+            nf_pwr_ctrl::nfPowerPath + "blade" + std::to_string(i);
+
+		/** setup nf/blade<x> dbus object */
+        nf_pwr_ctrl::nfBladeIface[i] = 
+            server.add_interface(
+                 nf_pwr_ctrl::nfBladePath[i], nf_pwr_ctrl::nfPowerIface);
+
+		/** add *Asserted* dbus property to nf/blade<x>/ dbus object */
+        nf_pwr_ctrl::nfBladeIface[i]->register_property("Asserted",
+            std::string("Power.Off"),
             sdbusplus::asio::PropertyPermission::readWrite);
-        nf_pwr_ctrl::nfpwrIface[i]->initialize();
+
+		/** add *Attached* dbus property to nf/blade<x>/ dbus object */
+        nf_pwr_ctrl::nfBladeIface[i]->register_property_r("Attached",
+            std::to_string(i) + std::string(".false"),
+			sdbusplus::vtable::property_::none,
+			//custom get
+			[](const std::string& property) {
+				std::string obj_path;
+				std::string token;
+				std::string line_name;
+				std::string delimiter = ".";
+				size_t pos = 0;
+
+				/* construct slot_x_prsnt as name of the GPIO line */
+				obj_path.assign(property);
+				while((pos = obj_path.find(delimiter)) != std::string::npos) {
+					token = obj_path.substr(0, pos);
+					obj_path.erase(0, pos + delimiter.length());
+				}
+				line_name = "slot_" + token + "_prsnt";
+
+				/* read GPIO line */
+                gpiod::line line;
+				int value;
+				nf_pwr_ctrl::GPIOLine(line_name, 0, line, value);
+				line.reset();
+
+				return token + "." + (value ? "true" : "false");	
+			});
+
+        nf_pwr_ctrl::nfBladeIface[i]->initialize();
     }
 
-    // Initialize SLOT_PWR GPIOs
-	// NOTE: All NF slots would be powered off (GPIO output 1) after booted
+    // Initialize SLOT_PWR and SLOT_PRSNT GPIOs
+	// NOTE: Each power GPIO pin of a NF slot would be asserted (poweroff) after booted
     gpiod::line gpioLine;
+	int value = 1;
     for (i = 0; i < MAX_NF_CARD_NUMS; i++) {
-        if (!nf_pwr_ctrl::setGPIOOutput(
-                nf_pwr_ctrl::nfpwrOut[i], 1, gpioLine))
+		// set output GPIO with initial value 1
+        if (!nf_pwr_ctrl::GPIOLine(
+                nf_pwr_ctrl::nfpwrOut[i], 1, gpioLine, value))
+            return -1;
+
+		// set input GPIO
+        if (!nf_pwr_ctrl::GPIOLine(
+                nf_pwr_ctrl::nfprsntIn[i], 0, gpioLine, value))
             return -1;
     }
     // Release gpioLine
     gpioLine.reset();
 
-    nf_pwr_ctrl::PowerStateMonitor();
+    nf_pwr_ctrl::PowerControl();
 
     nf_pwr_ctrl::io.run();
 

--- a/nf_pwr_ctrl.cpp
+++ b/nf_pwr_ctrl.cpp
@@ -176,7 +176,7 @@ int main(int argc, char* argv[])
 						nf_pwr_ctrl::GPIOLine(line_name, 0, line, value);
 						line.reset();
 							
-						return token + "." + (value ? "false" : "true");
+						return property.substr(0, pos + 1) + (value ? "false" : "true");
 			});
 
       nf_pwr_ctrl::nfBladeIface[i]->initialize();

--- a/nf_pwr_ctrl.cpp
+++ b/nf_pwr_ctrl.cpp
@@ -83,7 +83,7 @@ static void PowerControl()
                  token = obj_path.substr(0, pos);
                  obj_path.erase(0, pos + delimiter.length());
             }
-            line_name.assign(obj_path);
+            line_name = "slot_" + obj_path.substr(5, 2) + "_pwr";
             std::cerr << "line_name: " << line_name << "\n";
 
             try

--- a/xyz.openbmc_project.nf.power.manager.service.in
+++ b/xyz.openbmc_project.nf.power.manager.service.in
@@ -8,7 +8,7 @@ StartLimitBurst=10
 ExecStart=@bindir@/nf_pwr_ctrl
 SyslogIdentifier=nf_pwr_ctrl
 Type=dbus
-BusName=xyz.openbmc_project.NF.Blade.Power
+BusName=xyz.openbmc_project.nf.power.manager
 
 [Install]
 WantedBy=multi-user.target

--- a/xyz.openbmc_project.nf.power.manager.service.in
+++ b/xyz.openbmc_project.nf.power.manager.service.in
@@ -8,7 +8,7 @@ StartLimitBurst=10
 ExecStart=@bindir@/nf_pwr_ctrl
 SyslogIdentifier=nf_pwr_ctrl
 Type=dbus
-BusName=xyz.openbmc_project.nf.power.manager
+BusName=xyz.openbmc_project.NF.Blade.Power
 
 [Install]
 WantedBy=multi-user.target

--- a/xyz.openbmc_project.nf.power.manager.service.in
+++ b/xyz.openbmc_project.nf.power.manager.service.in
@@ -8,7 +8,7 @@ StartLimitBurst=10
 ExecStart=@bindir@/nf_pwr_ctrl
 SyslogIdentifier=nf_pwr_ctrl
 Type=dbus
-BusName=xyz.openbmc_project.Control.NF.Power
+BusName=xyz.openbmc_project.nf.power.manager
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
We add a read-only D-Bus attribute to each NF card to check whether one NF card is attached onto slot #.x

We rename D-Bus service as xyz.openbmc_project.nf.power.manager
and D-Bus interface as xyz.openbmc_project.NF.Blade.Power, respectively

D-Bus objects and attributes of each NF card are re-organized.
Currently, /xyz/openbmc_project/control/nf/bladex represents #.x of NF slot
/xyz/openbmc_project/control/nf/bladex/attr/Asserted controls the power on/off GPIO line.