### PR TITLE
Enable NF blade warm reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ could be set from host to control NF card slot.
 * DBus Interface: ```xyz.openbmc_project.NF.Blade.Power```
 
 * Attached Property (read-only): ```/xyz/openbmc_project/control/nf/blade<x>/attr/Attached```   
-(x.true: One NF card is attached onto slot #.x)   
-(x.false: NO NF card is attached onto slot #.x)   
+(true: One NF card is attached onto slot #.x)   
+(false: NO NF card is attached onto slot #.x)   
 Such property is controlled by GPIO line SLOT_PRSNT
 
 * Asserted Property (read-write): ```/xyz/openbmc_project/control/nf/blade<x>/attr/Asserted```
@@ -16,8 +16,8 @@ Such property is controlled by GPIO line SLOT_PRSNT
 Such property is controlled by GPIO line SLOT_PWR
 
 * WarmReset Property (read-write): ```/xyz/openbmc_project/control/nf/blade<x>/attr/Reset```
-(x.Force: trigger warm reset of the NF card on slot #.x)   
-(x.Done: warm reset of the NF card on slot #.x is finished)   
+(Force: trigger warm reset of the NF card on slot #.x, used in PUT)   
+(Done: warm reset of the NF card on slot #.x is finished, queried from GET)   
 Such property is controlled by GPIO line SLOT_RESETN
 
 SLOT_PRSNT, SLOT_PWR and SLOT_RESET are the GPIO pins from GPIO expanders and 

--- a/README.md
+++ b/README.md
@@ -5,18 +5,24 @@ could be set from host to control NF card slot.
 * DBus Service: ```xyz.openbmc_project.nf.power.manager```
 * DBus Interface: ```xyz.openbmc_project.NF.Blade.Power```
 
-* Attached Property (read-only): ```/xyz/openbmc_project/control/nf/bladex/attr/Attached```   
+* Attached Property (read-only): ```/xyz/openbmc_project/control/nf/blade<x>/attr/Attached```   
 (x.true: One NF card is attached onto slot #.x)   
 (x.false: NO NF card is attached onto slot #.x)   
 Such property is controlled by GPIO line SLOT_PRSNT
 
-* Asserted Property (read-write): ```/xyz/openbmc_project/control/nf/bladex/attr/Asserted```
-(Power.on: Power on the NF card on slot #.x)   
-(Power.off: Power off the NF card on slot #.x)   
+* Asserted Property (read-write): ```/xyz/openbmc_project/control/nf/blade<x>/attr/Asserted```
+(Power.On: Power on the NF card on slot #.x)   
+(Power.Off: Power off the NF card on slot #.x)   
 Such property is controlled by GPIO line SLOT_PWR
 
-SLOT_PRSNT and SLOT_PWR are the GPIO pins from GPIO expanders and 
+* WarmReset Property (read-write): ```/xyz/openbmc_project/control/nf/blade<x>/attr/Reset```
+(x.Force: trigger warm reset of the NF card on slot #.x)   
+(x.Done: warm reset of the NF card on slot #.x is finished)   
+Such property is controlled by GPIO line SLOT_RESETN
+
+SLOT_PRSNT, SLOT_PWR and SLOT_RESET are the GPIO pins from GPIO expanders and 
 they have to be set as gpio-line-names in Kernel DTS file.
 * SLOT_PRSNT gpio-line-names: ```slot_x_prsnt```     
 * SLOT_PWR gpio-line-names: ```slot_x_pwr```     
+* SLOT_RESETN gpio-line-names: ```slot_x_resetn```     
 

--- a/nf_pwr_ctrl.cpp
+++ b/nf_pwr_ctrl.cpp
@@ -33,221 +33,222 @@ static std::string nfresetnOut[MAX_NF_CARD_NUMS];
 static bool GPIOLine(const std::string& name, const int out,
                           gpiod::line& gpioLine, int& value)
 {
-    // Find the GPIO line
-    gpioLine = gpiod::find_line(name);
-    if (!gpioLine)
-    {
-        std::cerr << "Failed to find the " << name << " line.\n";
-        return false;
-    }
+  // Find the GPIO line
+  gpioLine = gpiod::find_line(name);
+  if (!gpioLine)
+  {
+    std::cerr << "Failed to find the " << name << " line.\n";
+    return false;
+  }
 
-    // Request GPIO line as input/output
-    try
-    {
-		if(out)
-			gpioLine.request({__FUNCTION__, gpiod::line_request::DIRECTION_OUTPUT},
+  // Request GPIO line as input/output
+  try
+  {
+    if(out)
+      gpioLine.request({__FUNCTION__, gpiod::line_request::DIRECTION_OUTPUT},
                          value);
-		else {
-			gpioLine.request({__FUNCTION__, gpiod::line_request::DIRECTION_INPUT});
-			value = gpioLine.get_value();
-		}
+    
+    else {
+      gpioLine.request({__FUNCTION__, gpiod::line_request::DIRECTION_INPUT});
+      value = gpioLine.get_value();
     }
-    catch (std::exception&)
-    {
-			std::cerr << "Failed to request " << name << "\n";
-      return false;
-    }
+  }
+  catch (std::exception&)
+  {
+    std::cerr << "Failed to request " << name << "\n";
+    return false;
+  }
 
-    return true;
+  return true;
 }
 
 static void PowerControl()
 {
-    static auto match = sdbusplus::bus::match::match(
-        *conn,
-        "type='signal',member='PropertiesChanged', "
-        "interface='org.freedesktop.DBus.Properties', "
-        "arg0namespace=xyz.openbmc_project.NF.Blade.Power",
-        [](sdbusplus::message::message& m) {
-            std::string intfName;
-            boost::container::flat_map<std::string,
-                                           std::variant<bool, std::string>>
-                    propertiesChanged;
+  static auto match = sdbusplus::bus::match::match(
+      *conn,
+      "type='signal',member='PropertiesChanged', "
+      "interface='org.freedesktop.DBus.Properties', "
+      "arg0namespace=xyz.openbmc_project.NF.Blade.Power",
+      [](sdbusplus::message::message& m) {
+        std::string intfName;
+        boost::container::flat_map<std::string, 
+             std::variant<bool, std::string>> propertiesChanged;
+             
+        m.read(intfName, propertiesChanged);
+        std::string obj_path;
+        obj_path = m.get_path();
 
-            m.read(intfName, propertiesChanged);
-            std::string obj_path;
-            obj_path = m.get_path();
+        std::string line_name;
+        size_t pos = 0;
+        std::string token;
+        std::string delimiter = "/";
+        while((pos = obj_path.find(delimiter)) != std::string::npos) {
+          token = obj_path.substr(0, pos);
+          obj_path.erase(0, pos + delimiter.length());
+        }
+        line_name = "slot_" + obj_path.substr(5, 2) + "_pwr";
+        std::cerr << "line_name: " << line_name << "\n";
+        
+        try
+        {
+          auto state = std::get<std::string>(propertiesChanged.begin()->second);
+          std::cerr << "state: " << state << "\n";
+          gpiod::line line;
+          int value;
+          
+          if (state == "Power.On")
+            value = 0;
+          else
+            value = 1;
+          
+          GPIOLine(line_name, 1, line, value);
 
-            std::string line_name;
-            size_t pos = 0;
-            std::string token;
-            std::string delimiter = "/";
-            while((pos = obj_path.find(delimiter)) != std::string::npos) {
-                 token = obj_path.substr(0, pos);
-                 obj_path.erase(0, pos + delimiter.length());
-            }
-            line_name = "slot_" + obj_path.substr(5, 2) + "_pwr";
-            std::cerr << "line_name: " << line_name << "\n";
-
-            try
-            {
-                auto state = std::get<std::string>(propertiesChanged.begin()->second);
-                std::cerr << "state: " << state << "\n";
-                gpiod::line line;
-                int value;
-								
-								if (state == "Power.On")
-									value = 0;
-								else
-									value = 1;
-								
-								GPIOLine(line_name, 1, line, value);
-
-                // Release line
-                line.reset();
-            }
-            catch (std::exception& e)
-            {
-                std::cerr << "Unable to read property\n";
-                return;
-            }
-        });
+          // Release line
+          line.reset();
+        }
+        catch (std::exception& e)
+        {
+          std::cerr << "Unable to read property\n";
+          return;
+        }
+      });
 }
 }
 
 int main(int argc, char* argv[])
 {
-    std::cerr << "Start NF card power control service...\n";
-    nf_pwr_ctrl::conn =
-        std::make_shared<sdbusplus::asio::connection>(nf_pwr_ctrl::io);
+  std::cerr << "Start NF card power control service...\n";
+  nf_pwr_ctrl::conn = 
+    std::make_shared<sdbusplus::asio::connection>(nf_pwr_ctrl::io);
+  
+  nf_pwr_ctrl::conn->request_name(nf_pwr_ctrl::nfPowerService);
+  
+  sdbusplus::asio::object_server server =
+    sdbusplus::asio::object_server(nf_pwr_ctrl::conn);
 
-    nf_pwr_ctrl::conn->request_name(nf_pwr_ctrl::nfPowerService);
-
-    sdbusplus::asio::object_server server =
-        sdbusplus::asio::object_server(nf_pwr_ctrl::conn);
-
-    std::string gpio_name;
-    int i;
-
-    for (i = 0; i < MAX_NF_CARD_NUMS; i++) {
-			/** construct slot_x_pwr gpio name */
-			gpio_name.clear();
-			gpio_name.assign(nf_pwr_ctrl::nfpwrTemplate);
-			gpio_name.replace(gpio_name.find("x"), 1, std::to_string(i));
-			
-			/** set slot_x_pwr physical gpio name */
-			nf_pwr_ctrl::nfpwrOut[i].assign(gpio_name);
-			
-			/** construct slot_x_prsnt gpio name */
-			gpio_name.clear();
-			gpio_name.assign(nf_pwr_ctrl::nfprsntTemplate);
-			gpio_name.replace(gpio_name.find("x"), 1, std::to_string(i));
-			
-			/** set slot_x_prsnt physical gpio name */
-			nf_pwr_ctrl::nfprsntIn[i].assign(gpio_name);
-
-			/** construct slot_x_resetn gpio name */
-			gpio_name.clear();
-			gpio_name.assign(nf_pwr_ctrl::nfresetnTemplate);
-			gpio_name.replace(gpio_name.find("x"), 1, std::to_string(i));
-			
-			/** set slot_x_prsnt physical gpio name */
-			nf_pwr_ctrl::nfresetnOut[i].assign(gpio_name);
-			
-			/** set nf blade dbus path */
-			nf_pwr_ctrl::nfBladePath[i] = 
-				nf_pwr_ctrl::nfPowerPath + "blade" + std::to_string(i);
-			
-			/** setup nf/blade<x> dbus object */
-			nf_pwr_ctrl::nfBladeIface[i] = 
-				server.add_interface(
-						nf_pwr_ctrl::nfBladePath[i], nf_pwr_ctrl::nfPowerIface);
-			
-			/** add *Asserted* dbus property to nf/blade<x>/ dbus object */
-			nf_pwr_ctrl::nfBladeIface[i]->register_property("Asserted",
-					std::string("Power.Off"),
-					sdbusplus::asio::PropertyPermission::readWrite);
-
-			/** add *Reset* dbus property to nf/blade<x>/ dbus object */
-			nf_pwr_ctrl::nfBladeIface[i]->register_property("WarmReset",
-					std::to_string(i) + std::string(".Done"),
-					//custom set
-					[](const std::string& req, const std::string& property) {
-						std::string line_name;
-						size_t pos = 0;
-							
-						/* construct slot_x_resetn as name of the GPIO line */
-						pos = property.find(".");
-						line_name = "slot_" + property.substr(0, pos) + "_resetn";
-
-						/* parsing warm reset command */
-						std::string reset_cmd;
-						pos = req.find(".");
-						reset_cmd = assign(req.substr(pos + 1, req.length()));
-
-						if (reset_cmd == "Force")
-						{
-						  /* reset output */
-						  gpiod::line line;
-						  int value = 0;
-						  nf_pwr_ctrl::GPIOLine(line_name, 1, line, value);
-						  line.reset();
-						}
-						/* There is no need to update D-Bus attribute value */
-						return 1;
-					});
-			
-			/** add *Attached* dbus property to nf/blade<x>/ dbus object */
-			nf_pwr_ctrl::nfBladeIface[i]->register_property_r("Attached",
-					std::to_string(i) + std::string(".false"),
-					sdbusplus::vtable::property_::none,
-					//custom get
-					[](const std::string& property) {
-						std::string line_name;
-						size_t pos = 0;
-							
-						/* construct slot_x_prsnt as name of the GPIO line */
-						pos = property.find(".");
-						line_name = "slot_" + property.substr(0, pos) + "_prsnt";
-							
-						/* read GPIO line */
-						gpiod::line line;
-						int value;
-						nf_pwr_ctrl::GPIOLine(line_name, 0, line, value);
-						line.reset();
-							
-						return property.substr(0, pos + 1) + (value ? "false" : "true");
-			});
-
-      nf_pwr_ctrl::nfBladeIface[i]->initialize();
-		}
-
-    // Initialize SLOT_PWR, SLOT_PRSNT and SLOT_RESETN GPIOs
-		// NOTE: Each power GPIO pin of a NF slot would be asserted (poweroff) after booted
-		// NOTE: Each warm reset GPIO pin of a NF slot would be asserted (no reset) after booted
-    gpiod::line gpioLine;
-		int value = 1;
-    for (i = 0; i < MAX_NF_CARD_NUMS; i++) {
-			// set output GPIO with initial value 1
-			if (!nf_pwr_ctrl::GPIOLine(
-						nf_pwr_ctrl::nfpwrOut[i], 1, gpioLine, value))
-				return -1;
-
-			if (!nf_pwr_ctrl::GPIOLine(
-						nf_pwr_ctrl::nfresetnOut[i], 1, gpioLine, value))
-				return -1;
-			
-			// set input GPIO
-			if (!nf_pwr_ctrl::GPIOLine(
-						nf_pwr_ctrl::nfprsntIn[i], 0, gpioLine, value))
-				return -1;
-    }
-    // Release gpioLine
-    gpioLine.reset();
-
-    nf_pwr_ctrl::PowerControl();
-
-    nf_pwr_ctrl::io.run();
-
-    return 0;
+  std::string gpio_name;
+  int i;
+  
+  for (i = 0; i < MAX_NF_CARD_NUMS; i++) {
+    /** construct slot_x_pwr gpio name */
+    gpio_name.clear();
+    gpio_name.assign(nf_pwr_ctrl::nfpwrTemplate);
+    gpio_name.replace(gpio_name.find("x"), 1, std::to_string(i));
+    
+    /** set slot_x_pwr physical gpio name */
+    nf_pwr_ctrl::nfpwrOut[i].assign(gpio_name);
+    
+    /** construct slot_x_prsnt gpio name */
+    gpio_name.clear();
+    gpio_name.assign(nf_pwr_ctrl::nfprsntTemplate);
+    gpio_name.replace(gpio_name.find("x"), 1, std::to_string(i));
+    
+    /** set slot_x_prsnt physical gpio name */
+    nf_pwr_ctrl::nfprsntIn[i].assign(gpio_name);
+    
+    /** construct slot_x_resetn gpio name */
+    gpio_name.clear();
+    gpio_name.assign(nf_pwr_ctrl::nfresetnTemplate);
+    gpio_name.replace(gpio_name.find("x"), 1, std::to_string(i));
+    
+    /** set slot_x_prsnt physical gpio name */
+    nf_pwr_ctrl::nfresetnOut[i].assign(gpio_name);
+    
+    /** set nf blade dbus path */
+    nf_pwr_ctrl::nfBladePath[i] = 
+      nf_pwr_ctrl::nfPowerPath + "blade" + std::to_string(i);
+    
+    /** setup nf/blade<x> dbus object */
+    nf_pwr_ctrl::nfBladeIface[i] = 
+      server.add_interface(
+          nf_pwr_ctrl::nfBladePath[i], nf_pwr_ctrl::nfPowerIface);
+    
+    /** add *Asserted* dbus property to nf/blade<x>/ dbus object */
+    nf_pwr_ctrl::nfBladeIface[i]->register_property("Asserted", 
+        std::string("Power.Off"), 
+        sdbusplus::asio::PropertyPermission::readWrite);
+    
+    /** add *Reset* dbus property to nf/blade<x>/ dbus object */
+    nf_pwr_ctrl::nfBladeIface[i]->register_property("WarmReset", 
+        std::to_string(i) + std::string(".Done"), 
+        //custom set
+        [](const std::string& req, const std::string& property) {
+          std::string line_name;
+          size_t pos = 0;
+          
+          /* construct slot_x_resetn as name of the GPIO line */
+          pos = property.find(".");
+          line_name = "slot_" + property.substr(0, pos) + "_resetn";
+          
+          /* parsing warm reset command */
+          std::string reset_cmd;
+          pos = req.find(".");
+          reset_cmd.assign(req.substr(pos + 1, req.length()));
+          
+          if (reset_cmd == "Force")
+          {
+            /* reset output */
+            gpiod::line line;
+            int value = 0;
+            nf_pwr_ctrl::GPIOLine(line_name, 1, line, value);
+            line.reset();
+          }
+          /* There is no need to update D-Bus attribute value */
+          return 1;
+        });
+    
+    /** add *Attached* dbus property to nf/blade<x>/ dbus object */
+    nf_pwr_ctrl::nfBladeIface[i]->register_property_r("Attached", 
+        std::to_string(i) + std::string(".false"), 
+        sdbusplus::vtable::property_::none,
+        //custom get
+        [](const std::string& property) {
+          std::string line_name;
+          size_t pos = 0;
+          
+          /* construct slot_x_prsnt as name of the GPIO line */
+          pos = property.find(".");
+          line_name = "slot_" + property.substr(0, pos) + "_prsnt";
+          
+          /* read GPIO line */
+          gpiod::line line;
+          int value;
+          nf_pwr_ctrl::GPIOLine(line_name, 0, line, value);
+          line.reset();
+          
+          return property.substr(0, pos + 1) + (value ? "false" : "true");
+      });
+    
+    nf_pwr_ctrl::nfBladeIface[i]->initialize();
+  }
+  
+  // Initialize SLOT_PWR, SLOT_PRSNT and SLOT_RESETN GPIOs
+  // NOTE: Each power GPIO pin of a NF slot would be asserted (poweroff) after booted
+  // NOTE: Each warm reset GPIO pin of a NF slot would be asserted (no reset) after booted
+  gpiod::line gpioLine;
+  int value = 1;
+  for (i = 0; i < MAX_NF_CARD_NUMS; i++) {
+    // set output GPIO with initial value 1
+    if (!nf_pwr_ctrl::GPIOLine(
+          nf_pwr_ctrl::nfpwrOut[i], 1, gpioLine, value))
+      return -1;
+    
+    if (!nf_pwr_ctrl::GPIOLine(
+          nf_pwr_ctrl::nfresetnOut[i], 1, gpioLine, value))
+      return -1;
+    
+    // set input GPIO
+    if (!nf_pwr_ctrl::GPIOLine(
+          nf_pwr_ctrl::nfprsntIn[i], 0, gpioLine, value))
+      return -1;
+  }
+  
+  // Release gpioLine
+  gpioLine.reset();
+  
+  nf_pwr_ctrl::PowerControl();
+  
+  nf_pwr_ctrl::io.run();
+  
+  return 0;
 }

--- a/nf_pwr_ctrl.cpp
+++ b/nf_pwr_ctrl.cpp
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <iostream>
 #include <ctype.h>
+#include <unistd.h>
 #include <sdbusplus/asio/object_server.hpp>
 #include <sdbusplus/vtable.hpp>
 #include <variant>
@@ -197,6 +198,12 @@ int main(int argc, char* argv[])
             gpiod::line line;
             int value = 0;
             nf_pwr_ctrl::GPIOLine(line_name, 1, line, value);
+
+            usleep(5000);
+
+            value = 1;
+            nf_pwr_ctrl::GPIOLine(line_name, 1, line, value);
+
             line.reset();
           }
           /* There is no need to update D-Bus attribute value */


### PR DESCRIPTION
Add GPIO control for warm reset of each NF blade card

A reset interval of 50ms is implemented in current version

We also pass the D-Bus object name in the capture list of each custom SET/GET C++ lamda functions, instead of maintaining the slot number in D-Bus attribute value.